### PR TITLE
Update dependend libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,28 +7,26 @@ The project is developed using only open source and cross platform dependencies.
 
 - GStreamer development and runtime  (v 1.16.0)
   - https://gstreamer.freedesktop.org
-- ADLINK OpenSplice DDS Community Edition (v 6.9.19)
+- ADLINK VortexOpenSplice DDS Community Edition (v 6.9.21)
   - https://github.com/ADLINK-IST/opensplice/releases  
-- Qt  (v 5.12)
+- Qt (v 6.2)
   - https://www.qt.io/
-- GoogleTest  (v.1.8.1)
+- CMake (v 3.1)
+  - https://cmake.org
+- Optionally: GoogleTest (v 1.8.1)
   - https://github.com/google/googletest.git
 
-While other version of these components might work, these are the ones that are guarant
+While other version of these components might work, these are the ones that should work.
 
 ## More information ##
-
 If you would like to use this software, have any questions, or want to know more about S2E Software, Systems and Control you can visit our website at http://www.s2e-systems.com
 
 # Build instructions #
-
 To build the software the CMakeLists.txt files use the following environment variables to search for the dependent libraries:
-
 1. OSPL_HOME pointing to the folder where OpenSplice is installed
 2. GSTREAMER_1_0_ROOT_X86_64 to the folder where GStreamer is installed
 
 For run the software the shared library binaries must be added to the PATH environment variable in Windows and to the ldconfig search directories in Linux. In Windows that may be for example:
-
 1. %OSPL_HOME%\bin
 2. %GSTREAMER_1_0_ROOT_X86_64%\bin
 3. %QTDIR%\bin

--- a/README.md
+++ b/README.md
@@ -1,22 +1,19 @@
 # Video over DDS Application (VoDA) #
 
 The Video over the Data Distribution Service Application (VoDA) is a software which allows real-time video data from a webcam to be transmitted using GStreamer and the Data Distribution Services (DDS) middleware. Using DDS as a communication mechanism, allows the video data to be transmitted in a data-centric manner with all the functionalities and advantages of the DDS Quality of Service (QoS) specifications. A demonstration video and detailed technical description is available on our website at http://www.s2e-systems.com/our-projects/videooverdds/
+This software should build with CMake on Windows and Linux. The source does also built on ARM computers such as Rasberry Pi's but requires some more build steps. 
 
 ## Dependencies ##
 The project is developed using only open source and cross platform dependencies. 
 
-- GStreamer development and runtime  (v 1.16.0)
+- GStreamer development and runtime  (v 1.18.5)
   - https://gstreamer.freedesktop.org
 - ADLINK VortexOpenSplice DDS Community Edition (v 6.9.21)
   - https://github.com/ADLINK-IST/opensplice/releases  
 - Qt (v 6.2)
   - https://www.qt.io/
-- CMake (v 3.1)
-  - https://cmake.org
-- Optionally: GoogleTest (v 1.8.1)
-  - https://github.com/google/googletest.git
 
-While other version of these components might work, these are the ones that should work.
+Other version of these components probably work as well.
 
 ## More information ##
 If you would like to use this software, have any questions, or want to know more about S2E Software, Systems and Control you can visit our website at http://www.s2e-systems.com

--- a/projects/Common/videowidgetpaintergst.cpp
+++ b/projects/Common/videowidgetpaintergst.cpp
@@ -18,6 +18,7 @@
 #include <QPainter>
 
 #include <gst/video/video.h>
+#include <stdexcept>
 
 VideoWidgetPainterGst::VideoWidgetPainterGst(GstAppSink* appSink) :
 	m_appSink(appSink)

--- a/projects/VideoDDSPublisher/CMakeLists.txt
+++ b/projects/VideoDDSPublisher/CMakeLists.txt
@@ -8,9 +8,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOMOC ON)
-find_package(Qt5Widgets CONFIG REQUIRED)
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
 
 find_package(GStreamer REQUIRED glib gobject base app video)
 
@@ -33,7 +35,7 @@ include_directories(VideoDDSPublisher
 )
 
 target_link_libraries(VideoDDSPublisher
-	Qt5::Widgets
-	GStreamer::gstreamer GStreamer::glib GStreamer::gobject GStreamer::base GStreamer::app GStreamer::video
-	OpenSplice::ddskernel OpenSplice::dcpsisocpp2 OpenSplice::dcpssacpp
+	PRIVATE Qt6::Widgets
+	PRIVATE GStreamer::gstreamer PRIVATE GStreamer::glib PRIVATE GStreamer::gobject PRIVATE GStreamer::base PRIVATE GStreamer::app PRIVATE GStreamer::video
+	PRIVATE OpenSplice::ddskernel PRIVATE OpenSplice::dcpsisocpp2 PRIVATE OpenSplice::dcpssacpp
 )

--- a/projects/VideoDDSPublisher/CMakeLists.txt
+++ b/projects/VideoDDSPublisher/CMakeLists.txt
@@ -12,7 +12,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOMOC ON)
-find_package(Qt6 REQUIRED COMPONENTS Widgets)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 
 find_package(GStreamer REQUIRED glib gobject base app video)
 
@@ -35,7 +36,7 @@ include_directories(VideoDDSPublisher
 )
 
 target_link_libraries(VideoDDSPublisher
-	PRIVATE Qt6::Widgets
+	PRIVATE Qt${QT_VERSION_MAJOR}::Widgets
 	PRIVATE GStreamer::gstreamer PRIVATE GStreamer::glib PRIVATE GStreamer::gobject PRIVATE GStreamer::base PRIVATE GStreamer::app PRIVATE GStreamer::video
 	PRIVATE OpenSplice::ddskernel PRIVATE OpenSplice::dcpsisocpp2 PRIVATE OpenSplice::dcpssacpp
 )

--- a/projects/VideoDDSPublisher/main.cpp
+++ b/projects/VideoDDSPublisher/main.cpp
@@ -15,6 +15,7 @@
 #include <QApplication>
 #include <QCommandLineParser>
 #include <QDebug>
+#include <stdexcept>
 
 #include "videoddspublisher.h"
 #include "videowidgetpaintergst.h"

--- a/projects/VideoDDSSubscriber/CMakeLists.txt
+++ b/projects/VideoDDSSubscriber/CMakeLists.txt
@@ -7,12 +7,14 @@ set(SourceDir ".")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-# Instruct CMake to run moc automatically when needed
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(CMAKE_AUTOMOC ON)
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
 
-find_package(Qt5Widgets CONFIG REQUIRED)
-
-find_package(GStreamer REQUIRED glib gobject base app video)
+find_package(GStreamer REQUIRED COMPONENTS glib gobject base app video)
 
 find_package(OpenSplice REQUIRED)
 OpenSplice_IDLCPP_GEN(${CommonDir}/VideoDDS.idl ${CMAKE_CURRENT_BINARY_DIR})
@@ -34,7 +36,7 @@ include_directories(VideoDDSSubscriber
 )
 
 target_link_libraries(VideoDDSSubscriber
-	Qt5::Widgets
-	GStreamer::gstreamer GStreamer::gobject GStreamer::glib GStreamer::base GStreamer::app GStreamer::video
-	OpenSplice::ddskernel OpenSplice::dcpsisocpp2 OpenSplice::dcpssacpp
+	PRIVATE Qt6::Widgets
+	PRIVATE GStreamer::gstreamer PRIVATE GStreamer::gobject PRIVATE GStreamer::glib PRIVATE GStreamer::base PRIVATE GStreamer::app PRIVATE GStreamer::video
+	PRIVATE OpenSplice::ddskernel PRIVATE OpenSplice::dcpsisocpp2 PRIVATE OpenSplice::dcpssacpp
 )

--- a/projects/VideoDDSSubscriber/CMakeLists.txt
+++ b/projects/VideoDDSSubscriber/CMakeLists.txt
@@ -12,7 +12,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_AUTOMOC ON)
-find_package(Qt6 REQUIRED COMPONENTS Widgets)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 
 find_package(GStreamer REQUIRED COMPONENTS glib gobject base app video)
 
@@ -36,7 +37,7 @@ include_directories(VideoDDSSubscriber
 )
 
 target_link_libraries(VideoDDSSubscriber
-	PRIVATE Qt6::Widgets
+	PRIVATE Qt${QT_VERSION_MAJOR}::Widgets
 	PRIVATE GStreamer::gstreamer PRIVATE GStreamer::gobject PRIVATE GStreamer::glib PRIVATE GStreamer::base PRIVATE GStreamer::app PRIVATE GStreamer::video
 	PRIVATE OpenSplice::ddskernel PRIVATE OpenSplice::dcpsisocpp2 PRIVATE OpenSplice::dcpssacpp
 )


### PR DESCRIPTION
Update usage of Qt5 to Qt6. This did only involve updating the CMake files. OpenSplice and GStreamer update did not require any changes (only notes in Readme). 